### PR TITLE
대문 페이지에서 DB에 정보가 등록되지 않은 사용자에 대한 표시 개선 

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,11 @@
 	<div>하은행에 온 것을 환영해.</div>
 	{#if username}
 		<div>
-			너의 이름은 {username}(이)야.
+			{#if username === 'Unknown'}
+				너의 정보는 아직 하은행에 등록되지 않았어.
+			{:else}
+				너의 이름은 {username}(이)야.
+			{/if}
 		</div>
 	{/if}
 	{#if land?.name && residence?.id}


### PR DESCRIPTION
이 PR은 DB의 `people` 테이블에 정보가 등록되지 않은 사용자가 하은행 페이지에서 로그인했을 때, 본문에 출력하는 내용을 더 자연스럽게 수정할 것을 제안하고 있어.

This PR resolves #1.